### PR TITLE
Update Product.php

### DIFF
--- a/app/code/community/BL/CustomGrid/Model/Grid/Editor/Product.php
+++ b/app/code/community/BL/CustomGrid/Model/Grid/Editor/Product.php
@@ -206,7 +206,15 @@ class BL_CustomGrid_Model_Grid_Editor_Product extends BL_CustomGrid_Model_Grid_E
         
         /** @var Mage_Catalog_Model_Product $product */
         $product = Mage::getModel('catalog/product');
-        $product->setStoreId($storeId)->setData('_edit_mode', true)->load($entityId);
+        $product->setStoreId($storeId)->setData('_edit_mode', true);
+
+        /**
+         * Reset cached attributes in resource singleton and load new from product attributes set
+         */
+        $product->getResource()
+            ->unsetAttributes();
+
+        $product->load($entityId);
         
         return $product;
     }


### PR DESCRIPTION
Used version: 1.0.0.1

Description:
There are two product:
- product_a with attribute_set_x
- product_b with attribute_set_y

As a store administrator tried to change product_a from product grid.

Expected: only attribute_set_x attributes should be changed
Actual: attribute_set_x attributes changed but also attribute_set_y attributes changed to default values

Problem:
All available attributes loaded in catalog product resource model (it is singleton) in app/code/community/BL/CustomGrid/Model/Grid/Type/Product.php:72
Then during saving product all attributes values change to default values even if they are not in product attribute set

Solution:
Reset previously loaded attributes cache before product initialization